### PR TITLE
Add mint monitor snapshot API and dashboard panel

### DIFF
--- a/src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.html
+++ b/src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.html
@@ -23,6 +23,34 @@
 		></orc-mint-general-balance-sheet>
 	</div>
 
+	<div class="mint-monitor-panel p-1 m-b-1">
+		<div class="mint-monitor-title">Mint Monitor</div>
+		@if (loading_monitor()) {
+			<div class="font-size-s orc-outline-color">Loading monitor snapshot...</div>
+		} @else if (mint_monitor) {
+			<div class="mint-monitor-grid font-size-s">
+				<div>
+					<div class="orc-outline-color">DB entries</div>
+					<div class="font-weight-semi-bold">{{ mint_monitor.db_entries_total | number: '1.0-0' }}</div>
+				</div>
+				<div>
+					<div class="orc-outline-color">Requests ({{ mint_monitor.recent_window_hours }}h)</div>
+					<div class="font-weight-semi-bold">{{ mint_monitor.request_count_recent | number: '1.0-0' }}</div>
+				</div>
+				<div>
+					<div class="orc-outline-color">Disk free</div>
+					<div class="font-weight-semi-bold">{{ mint_monitor.disk_free_bytes / 1073741824 | number: '1.1-1' }} GB</div>
+				</div>
+				<div>
+					<div class="orc-outline-color">CPU usage</div>
+					<div class="font-weight-semi-bold">{{ mint_monitor.cpu_usage_percent | number: '1.0-1' }}%</div>
+				</div>
+			</div>
+		} @else {
+			<div class="font-size-s orc-outline-color">Monitor snapshot unavailable.</div>
+		}
+	</div>
+
 	<div class="mint-analytic-control-panel">
 		<div class="flex flex-justify-between flex-gap-1 flex-items-end">
 			@if (device_type() === 'desktop') {

--- a/src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.scss
+++ b/src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.scss
@@ -15,6 +15,22 @@ $analytics-offset: 86px;
 	@extend %flex-wrap;
 }
 
+.mint-monitor-panel {
+	@extend %orc-surface-bg;
+	@extend %orc-corner-extra-large;
+}
+
+.mint-monitor-title {
+	@extend %title-s;
+	@extend %p-b-0-5;
+}
+
+.mint-monitor-grid {
+	@extend %grid;
+	@extend %flex-gap-1;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .mint-analytic-control-panel {
 	@extend %p-t-1;
 	@extend %orc-surface-bg;

--- a/src/client/modules/mint/services/mint/mint.queries.ts
+++ b/src/client/modules/mint/services/mint/mint.queries.ts
@@ -128,6 +128,25 @@ export const MINT_KEYSETS_QUERY = `{
     }
 }`;
 
+export const MINT_MONITOR_QUERY = `{
+	mint_monitor {
+		db_entries_total
+		mint_quotes_total
+		melt_quotes_total
+		proof_groups_total
+		promise_groups_total
+		request_count_recent
+		recent_window_hours
+		disk_free_bytes
+		disk_total_bytes
+		cpu_cores
+		cpu_load_1m
+		cpu_load_5m
+		cpu_load_15m
+		cpu_usage_percent
+	}
+}`;
+
 export const MINT_ANALYTICS_BALANCES_QUERY = `
 query MintAnalyticsBalances($units: [MintUnit!], $date_start: UnixTimestamp, $date_end: UnixTimestamp, $interval: MintAnalyticsInterval, $timezone: Timezone) {
 	mint_analytics_balances(units: $units, date_start: $date_start, date_end: $date_end, interval: $interval, timezone: $timezone) {

--- a/src/client/modules/mint/services/mint/mint.service.ts
+++ b/src/client/modules/mint/services/mint/mint.service.ts
@@ -53,6 +53,7 @@ import {
 	MintDatabaseRestoreResponse,
 	MintProofGroupStatsResponse,
 	MintFeesResponse,
+	MintMonitorResponse,
 } from '@client/modules/mint/types/mint.types';
 import {ApiService} from '@client/modules/api/services/api/api.service';
 import {CacheService} from '@client/modules/cache/services/cache/cache.service';
@@ -77,6 +78,7 @@ import {
 	MINT_QUOTE_TTLS_QUERY,
 	MINT_BALANCES_QUERY,
 	MINT_KEYSETS_QUERY,
+	MINT_MONITOR_QUERY,
 	MINT_ANALYTICS_BALANCES_QUERY,
 	MINT_ANALYTICS_MINTS_QUERY,
 	MINT_ANALYTICS_MELTS_QUERY,
@@ -828,6 +830,21 @@ export class MintService {
 			}),
 			catchError((error) => {
 				console.error('Error loading mint proof group stats:', error);
+				return throwError(() => error);
+			}),
+		);
+	}
+
+	public loadMintMonitor() {
+		const query = getApiQuery(MINT_MONITOR_QUERY, {});
+
+		return this.http.post<OrchardRes<MintMonitorResponse>>(this.apiService.api, query).pipe(
+			map((response) => {
+				if (response.errors) throw new OrchardErrors(response.errors);
+				return response.data;
+			}),
+			catchError((error) => {
+				console.error('Error loading mint monitor snapshot:', error);
 				return throwError(() => error);
 			}),
 		);

--- a/src/client/modules/mint/types/mint.types.ts
+++ b/src/client/modules/mint/types/mint.types.ts
@@ -240,6 +240,27 @@ export type MintFeesResponse = {
 	mint_fees: OrchardMintFee[];
 };
 
+export type OrchardMintMonitor = {
+	db_entries_total: number;
+	mint_quotes_total: number;
+	melt_quotes_total: number;
+	proof_groups_total: number;
+	promise_groups_total: number;
+	request_count_recent: number;
+	recent_window_hours: number;
+	disk_free_bytes: number;
+	disk_total_bytes: number;
+	cpu_cores: number;
+	cpu_load_1m: number;
+	cpu_load_5m: number;
+	cpu_load_15m: number;
+	cpu_usage_percent: number;
+};
+
+export type MintMonitorResponse = {
+	mint_monitor: OrchardMintMonitor;
+};
+
 export type MintNut04QuoteUpdateResponse = {
 	mint_nut04_quote_update: OrchardMintNut04QuoteUpdate;
 };

--- a/src/server/modules/api/api.module.ts
+++ b/src/server/modules/api/api.module.ts
@@ -37,6 +37,7 @@ import {MintProofModule} from './mint/proof/mintproof.module';
 import {MintAnalyticsModule} from './mint/analytics/mintanalytics.module';
 import {MintCountModule} from './mint/count/mintcount.module';
 import {MintFeeModule} from './mint/fee/mintfee.module';
+import {MintMonitorModule} from './mint/monitor/mintmonitor.module';
 // AI Endpoints
 import {AiModelModule} from './ai/model/aimodel.module';
 import {AiAgentModule} from './ai/agent/aiagent.module';
@@ -83,6 +84,7 @@ import {ApiSettingModule} from './setting/setting.module';
 		MintAnalyticsModule,
 		MintCountModule,
 		MintFeeModule,
+		MintMonitorModule,
 		AiModelModule,
 		AiAgentModule,
 		AiChatModule,

--- a/src/server/modules/api/mint/monitor/mintmonitor.model.ts
+++ b/src/server/modules/api/mint/monitor/mintmonitor.model.ts
@@ -1,0 +1,64 @@
+/* Core Dependencies */
+import {Field, Float, Int, ObjectType} from '@nestjs/graphql';
+
+@ObjectType()
+export class OrchardMintMonitor {
+	@Field(() => Int)
+	db_entries_total: number;
+
+	@Field(() => Int)
+	mint_quotes_total: number;
+
+	@Field(() => Int)
+	melt_quotes_total: number;
+
+	@Field(() => Int)
+	proof_groups_total: number;
+
+	@Field(() => Int)
+	promise_groups_total: number;
+
+	@Field(() => Int)
+	request_count_recent: number;
+
+	@Field(() => Int)
+	recent_window_hours: number;
+
+	@Field(() => Float)
+	disk_free_bytes: number;
+
+	@Field(() => Float)
+	disk_total_bytes: number;
+
+	@Field(() => Int)
+	cpu_cores: number;
+
+	@Field(() => Float)
+	cpu_load_1m: number;
+
+	@Field(() => Float)
+	cpu_load_5m: number;
+
+	@Field(() => Float)
+	cpu_load_15m: number;
+
+	@Field(() => Float)
+	cpu_usage_percent: number;
+
+	constructor(data: OrchardMintMonitor) {
+		this.db_entries_total = data.db_entries_total;
+		this.mint_quotes_total = data.mint_quotes_total;
+		this.melt_quotes_total = data.melt_quotes_total;
+		this.proof_groups_total = data.proof_groups_total;
+		this.promise_groups_total = data.promise_groups_total;
+		this.request_count_recent = data.request_count_recent;
+		this.recent_window_hours = data.recent_window_hours;
+		this.disk_free_bytes = data.disk_free_bytes;
+		this.disk_total_bytes = data.disk_total_bytes;
+		this.cpu_cores = data.cpu_cores;
+		this.cpu_load_1m = data.cpu_load_1m;
+		this.cpu_load_5m = data.cpu_load_5m;
+		this.cpu_load_15m = data.cpu_load_15m;
+		this.cpu_usage_percent = data.cpu_usage_percent;
+	}
+}

--- a/src/server/modules/api/mint/monitor/mintmonitor.module.ts
+++ b/src/server/modules/api/mint/monitor/mintmonitor.module.ts
@@ -1,0 +1,16 @@
+/* Core Dependencies */
+import {Module} from '@nestjs/common';
+import {ConfigModule} from '@nestjs/config';
+/* Application Dependencies */
+import {CashuMintDatabaseModule} from '@server/modules/cashu/mintdb/cashumintdb.module';
+import {ErrorModule} from '@server/modules/error/error.module';
+import {MintService} from '@server/modules/api/mint/mint.service';
+/* Local Dependencies */
+import {MintMonitorService} from './mintmonitor.service';
+import {MintMonitorResolver} from './mintmonitor.resolver';
+
+@Module({
+	imports: [ConfigModule, CashuMintDatabaseModule, ErrorModule],
+	providers: [MintMonitorResolver, MintMonitorService, MintService],
+})
+export class MintMonitorModule {}

--- a/src/server/modules/api/mint/monitor/mintmonitor.resolver.ts
+++ b/src/server/modules/api/mint/monitor/mintmonitor.resolver.ts
@@ -1,0 +1,20 @@
+/* Core Dependencies */
+import {Logger} from '@nestjs/common';
+import {Resolver, Query} from '@nestjs/graphql';
+/* Local Dependencies */
+import {MintMonitorService} from './mintmonitor.service';
+import {OrchardMintMonitor} from './mintmonitor.model';
+
+@Resolver(() => OrchardMintMonitor)
+export class MintMonitorResolver {
+	private readonly logger = new Logger(MintMonitorResolver.name);
+
+	constructor(private mintMonitorService: MintMonitorService) {}
+
+	@Query(() => OrchardMintMonitor)
+	async mint_monitor(): Promise<OrchardMintMonitor> {
+		const tag = 'GET { mint_monitor }';
+		this.logger.debug(tag);
+		return await this.mintMonitorService.getMintMonitor(tag);
+	}
+}

--- a/src/server/modules/api/mint/monitor/mintmonitor.service.spec.ts
+++ b/src/server/modules/api/mint/monitor/mintmonitor.service.spec.ts
@@ -1,0 +1,94 @@
+/* Core Dependencies */
+import {Test, TestingModule} from '@nestjs/testing';
+import {ConfigService} from '@nestjs/config';
+import {expect} from '@jest/globals';
+/* Application Dependencies */
+import {CashuMintDatabaseService} from '@server/modules/cashu/mintdb/cashumintdb.service';
+import {MintService} from '@server/modules/api/mint/mint.service';
+import {ErrorService} from '@server/modules/error/error.service';
+import {OrchardErrorCode} from '@server/modules/error/error.types';
+import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
+/* Local Dependencies */
+import {MintMonitorService} from './mintmonitor.service';
+import {OrchardMintMonitor} from './mintmonitor.model';
+
+describe('MintMonitorService', () => {
+	let mintMonitorService: MintMonitorService;
+	let mintDbService: jest.Mocked<CashuMintDatabaseService>;
+	let errorService: jest.Mocked<ErrorService>;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				MintMonitorService,
+				{
+					provide: ConfigService,
+					useValue: {
+						get: jest.fn().mockReturnValue('/tmp/orchard.db'),
+					},
+				},
+				{
+					provide: CashuMintDatabaseService,
+					useValue: {
+						getMintCountMintQuotes: jest.fn(),
+						getMintCountMeltQuotes: jest.fn(),
+						getMintCountProofGroups: jest.fn(),
+						getMintCountPromiseGroups: jest.fn(),
+					},
+				},
+				{
+					provide: MintService,
+					useValue: {withDbClient: jest.fn((fn: any) => fn({}))},
+				},
+				{
+					provide: ErrorService,
+					useValue: {resolveError: jest.fn()},
+				},
+			],
+		}).compile();
+
+		mintMonitorService = module.get<MintMonitorService>(MintMonitorService);
+		mintDbService = module.get(CashuMintDatabaseService);
+		errorService = module.get(ErrorService);
+	});
+
+	it('should be defined', () => {
+		expect(mintMonitorService).toBeDefined();
+	});
+
+	it('getMintMonitor returns db and host metrics snapshot', async () => {
+		mintDbService.getMintCountMintQuotes.mockResolvedValueOnce(10 as any).mockResolvedValueOnce(3 as any);
+		mintDbService.getMintCountMeltQuotes.mockResolvedValueOnce(6 as any).mockResolvedValueOnce(2 as any);
+		mintDbService.getMintCountProofGroups.mockResolvedValue(4 as any);
+		mintDbService.getMintCountPromiseGroups.mockResolvedValue(8 as any);
+		jest.spyOn(mintMonitorService as any, 'getHostMetrics').mockReturnValue({
+			disk_free_bytes: 1000,
+			disk_total_bytes: 5000,
+			cpu_cores: 8,
+			cpu_load_1m: 2,
+			cpu_load_5m: 1.5,
+			cpu_load_15m: 1.2,
+			cpu_usage_percent: 25,
+		});
+
+		const result = await mintMonitorService.getMintMonitor('TAG');
+		expect(result).toBeInstanceOf(OrchardMintMonitor);
+		expect(result.db_entries_total).toBe(28);
+		expect(result.mint_quotes_total).toBe(10);
+		expect(result.melt_quotes_total).toBe(6);
+		expect(result.proof_groups_total).toBe(4);
+		expect(result.promise_groups_total).toBe(8);
+		expect(result.request_count_recent).toBe(5);
+		expect(result.recent_window_hours).toBe(24);
+		expect(result.disk_free_bytes).toBe(1000);
+		expect(result.disk_total_bytes).toBe(5000);
+		expect(result.cpu_cores).toBe(8);
+		expect(result.cpu_usage_percent).toBe(25);
+	});
+
+	it('wraps errors via resolveError and throws OrchardApiError', async () => {
+		mintDbService.getMintCountMintQuotes.mockRejectedValue(new Error('boom'));
+		errorService.resolveError.mockReturnValue({code: OrchardErrorCode.MintDatabaseSelectError});
+		await expect(mintMonitorService.getMintMonitor('MY_TAG')).rejects.toBeInstanceOf(OrchardApiError);
+	});
+});

--- a/src/server/modules/api/mint/monitor/mintmonitor.service.ts
+++ b/src/server/modules/api/mint/monitor/mintmonitor.service.ts
@@ -1,0 +1,118 @@
+/* Core Dependencies */
+import {Injectable, Logger} from '@nestjs/common';
+import {ConfigService} from '@nestjs/config';
+import {existsSync, statfsSync} from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+/* Application Dependencies */
+import {CashuMintDatabaseService} from '@server/modules/cashu/mintdb/cashumintdb.service';
+import {MintService} from '@server/modules/api/mint/mint.service';
+import {ErrorService} from '@server/modules/error/error.service';
+import {OrchardErrorCode} from '@server/modules/error/error.types';
+import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
+/* Local Dependencies */
+import {OrchardMintMonitor} from './mintmonitor.model';
+
+@Injectable()
+export class MintMonitorService {
+	private readonly logger = new Logger(MintMonitorService.name);
+	private static readonly RECENT_WINDOW_HOURS = 24;
+
+	constructor(
+		private configService: ConfigService,
+		private cashuMintDatabaseService: CashuMintDatabaseService,
+		private mintService: MintService,
+		private errorService: ErrorService,
+	) {}
+
+	async getMintMonitor(tag: string): Promise<OrchardMintMonitor> {
+		return this.mintService.withDbClient(async (client) => {
+			try {
+				const now = Math.floor(Date.now() / 1000);
+				const recent_window_start = now - MintMonitorService.RECENT_WINDOW_HOURS * 60 * 60;
+				const [mint_quotes_total, melt_quotes_total, proof_groups_total, promise_groups_total] = await Promise.all([
+					this.cashuMintDatabaseService.getMintCountMintQuotes(client),
+					this.cashuMintDatabaseService.getMintCountMeltQuotes(client),
+					this.cashuMintDatabaseService.getMintCountProofGroups(client),
+					this.cashuMintDatabaseService.getMintCountPromiseGroups(client),
+				]);
+				const [mint_quotes_recent, melt_quotes_recent] = await Promise.all([
+					this.cashuMintDatabaseService.getMintCountMintQuotes(client, {
+						date_start: recent_window_start,
+						date_end: now,
+					}),
+					this.cashuMintDatabaseService.getMintCountMeltQuotes(client, {
+						date_start: recent_window_start,
+						date_end: now,
+					}),
+				]);
+				const host_metrics = this.getHostMetrics();
+				return new OrchardMintMonitor({
+					db_entries_total: mint_quotes_total + melt_quotes_total + proof_groups_total + promise_groups_total,
+					mint_quotes_total,
+					melt_quotes_total,
+					proof_groups_total,
+					promise_groups_total,
+					request_count_recent: mint_quotes_recent + melt_quotes_recent,
+					recent_window_hours: MintMonitorService.RECENT_WINDOW_HOURS,
+					disk_free_bytes: host_metrics.disk_free_bytes,
+					disk_total_bytes: host_metrics.disk_total_bytes,
+					cpu_cores: host_metrics.cpu_cores,
+					cpu_load_1m: host_metrics.cpu_load_1m,
+					cpu_load_5m: host_metrics.cpu_load_5m,
+					cpu_load_15m: host_metrics.cpu_load_15m,
+					cpu_usage_percent: host_metrics.cpu_usage_percent,
+				});
+			} catch (error) {
+				const orchard_error = this.errorService.resolveError(this.logger, error, tag, {
+					errord: OrchardErrorCode.MintDatabaseSelectError,
+				});
+				throw new OrchardApiError(orchard_error);
+			}
+		});
+	}
+
+	private getHostMetrics(): {
+		disk_free_bytes: number;
+		disk_total_bytes: number;
+		cpu_cores: number;
+		cpu_load_1m: number;
+		cpu_load_5m: number;
+		cpu_load_15m: number;
+		cpu_usage_percent: number;
+	} {
+		const cpu_cores = Math.max(os.cpus().length, 1);
+		const [cpu_load_1m, cpu_load_5m, cpu_load_15m] = os.loadavg();
+		const cpu_usage_percent = Math.min((cpu_load_1m / cpu_cores) * 100, 100);
+
+		let disk_free_bytes = 0;
+		let disk_total_bytes = 0;
+		try {
+			const target_path = this.getDiskTargetPath();
+			const disk_stats = statfsSync(target_path);
+			const block_size = Number(disk_stats.bsize);
+			disk_free_bytes = Number(disk_stats.bavail) * block_size;
+			disk_total_bytes = Number(disk_stats.blocks) * block_size;
+		} catch (error) {
+			this.logger.warn(`Unable to collect disk metrics: ${String(error)}`);
+		}
+
+		return {
+			disk_free_bytes,
+			disk_total_bytes,
+			cpu_cores,
+			cpu_load_1m,
+			cpu_load_5m,
+			cpu_load_15m,
+			cpu_usage_percent,
+		};
+	}
+
+	private getDiskTargetPath(): string {
+		const configured_db_path = this.configService.get<string>('database.path');
+		if (!configured_db_path || configured_db_path.includes('://')) return process.cwd();
+		const resolved_db_path = path.isAbsolute(configured_db_path) ? configured_db_path : path.resolve(process.cwd(), configured_db_path);
+		const db_dir = path.dirname(resolved_db_path);
+		return existsSync(db_dir) ? db_dir : process.cwd();
+	}
+}


### PR DESCRIPTION
## Summary
- add a new `mint_monitor` GraphQL query that returns:
  - mint DB entry counts (mints, melts, proofs, promises, total)
  - recent request volume (mint + melt quotes over trailing 24h)
  - host-level disk and CPU snapshot metrics
- expose the query in the client `MintService` (`loadMintMonitor`)
- add a Mint Dashboard monitoring panel that surfaces the snapshot directly in the admin UI

## Why
This is a focused contribution toward `cashubtc/nutshell#556`'s monitoring requirement:
- "number of entries in the database"
- "number of requests in recent past"
- "free disk space" and "used CPU"

## Validation
- `npm run test:server -- src/server/modules/api/mint/monitor/mintmonitor.service.spec.ts`
- `npx eslint src/server/modules/api/mint/monitor/*.ts src/client/modules/mint/services/mint/mint.service.ts src/client/modules/mint/services/mint/mint.queries.ts src/client/modules/mint/types/mint.types.ts src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.ts`
- `npx prettier --check src/server/modules/api/mint/monitor/*.ts src/client/modules/mint/services/mint/mint.service.ts src/client/modules/mint/services/mint/mint.queries.ts src/client/modules/mint/types/mint.types.ts src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.ts src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.html src/client/modules/mint/modules/mint-subsection-dashboard/components/mint-subsection-dashboard/mint-subsection-dashboard.component.scss src/server/modules/api/api.module.ts`

## Notes
- Full `npm run build` exits early in this local environment (Node `v25.2.1`, project expects `>=22 <23`).
- The feature itself is covered by targeted server tests + lint/format checks above.
