### PR TITLE
Add admin ecash issuance flow for mint quotes

### DIFF
--- a/src/client/modules/mint/modules/mint-subsection-database/components/mint-subsection-database/mint-subsection-database.component.html
+++ b/src/client/modules/mint/modules/mint-subsection-database/components/mint-subsection-database/mint-subsection-database.component.html
@@ -73,6 +73,12 @@
 								<span>Restore Backup</span>
 							</div>
 						</button>
+						<button mat-menu-item (click)="onIssue()">
+							<div class="flex flex-items-center flex-gap-0-5">
+								<mat-icon>payments</mat-icon>
+								<span>Issue Ecash (Admin)</span>
+							</div>
+						</button>
 						<button mat-menu-item (click)="onRefresh()">
 							<div class="flex flex-items-center flex-gap-0-5">
 								<mat-icon>refresh</mat-icon>
@@ -107,6 +113,55 @@
 				[form_group]="form_restore"
 				(close)="onClose()"
 			></orc-mint-subsection-database-form-restore>
+		</div>
+	</div>
+	<div class="orc-animation-collapsible" [class.animation-open]="form_mode === 'ISSUE'">
+		<div class="orc-animation-collapsible-inner">
+			<div class="mint-database-form-target" #issue_form></div>
+			<div class="p-t-1">
+				<mat-card appearance="outlined" class="relative overflow-hidden">
+					<mat-card-content class="orc-surface-container-low-bg">
+						<div class="absolute top-0-5 right-0-5">
+							<button mat-icon-button (click)="onClose()">
+								<mat-icon>close</mat-icon>
+							</button>
+						</div>
+						<div class="title-m p-b-1">Issue Ecash Without Payment</div>
+						<form class="flex flex-column flex-gap-1" [formGroup]="form_issue" (ngSubmit)="onIssueSubmit()">
+							<div class="flex flex-gap-1 flex-wrap">
+								<mat-form-field appearance="fill" hideRequiredMarker="true" class="orc-dynamic-form-field orc-hot-form-field">
+									<mat-label>Amount</mat-label>
+									<input type="number" min="1" matInput formControlName="amount" />
+								</mat-form-field>
+								<mat-form-field appearance="fill" hideRequiredMarker="true" class="orc-dynamic-form-field orc-hot-form-field">
+									<mat-label>Unit</mat-label>
+									<mat-select formControlName="unit">
+										@for (unit of unit_options; track unit.value) {
+											<mat-option [value]="unit.value">{{ unit.label }}</mat-option>
+										}
+									</mat-select>
+								</mat-form-field>
+								<mat-form-field appearance="fill" hideRequiredMarker="true" class="orc-dynamic-form-field orc-hot-form-field">
+									<mat-label>Method</mat-label>
+									<input type="text" matInput formControlName="method" />
+								</mat-form-field>
+							</div>
+							<mat-form-field appearance="fill" hideRequiredMarker="true" class="w-full orc-dynamic-form-field orc-hot-form-field">
+								<mat-label>Description (optional)</mat-label>
+								<input type="text" matInput formControlName="description" />
+							</mat-form-field>
+							<div class="font-size-xs orc-outline-color">
+								Creates a mint quote and immediately marks it paid via admin RPC so ecash can be issued without invoice settlement.
+							</div>
+							<div class="flex flex-justify-end">
+								<button mat-flat-button class="orc-flat-button" type="submit">
+									Issue Ecash
+								</button>
+							</div>
+						</form>
+					</mat-card-content>
+				</mat-card>
+			</div>
 		</div>
 	</div>
 

--- a/src/client/modules/mint/modules/mint-subsection-database/components/mint-subsection-database/mint-subsection-database.component.ts
+++ b/src/client/modules/mint/modules/mint-subsection-database/components/mint-subsection-database/mint-subsection-database.component.ts
@@ -52,6 +52,7 @@ import {MintUnit, MintQuoteState, MeltQuoteState, MintProofState, AiAgent, AiFun
 enum FormMode {
 	CREATE = 'CREATE',
 	RESTORE = 'RESTORE',
+	ISSUE = 'ISSUE',
 }
 
 @Component({
@@ -69,6 +70,7 @@ export class MintSubsectionDatabaseComponent implements ComponentCanDeactivate, 
 
 	@ViewChild('backup_form', {static: false}) backup_form!: ElementRef;
 	@ViewChild('restore_form', {static: false}) restore_form!: ElementRef;
+	@ViewChild('issue_form', {static: false}) issue_form!: ElementRef;
 
 	public page_settings!: NonNullableMintDatabaseSettings;
 	public filter: string = '';
@@ -87,6 +89,12 @@ export class MintSubsectionDatabaseComponent implements ComponentCanDeactivate, 
 	public form_restore: FormGroup = new FormGroup({
 		file: new FormControl(null, [Validators.required]),
 		filebase64: new FormControl(null, [Validators.required]),
+	});
+	public form_issue: FormGroup = new FormGroup({
+		amount: new FormControl<number | null>(null, [Validators.required, Validators.min(1)]),
+		unit: new FormControl<MintUnit | null>(null, [Validators.required]),
+		method: new FormControl<string>('bolt11', [Validators.required]),
+		description: new FormControl<string>(''),
 	});
 	public unit_options!: {value: string; label: string}[];
 	public state_options!: string[];
@@ -416,6 +424,9 @@ export class MintSubsectionDatabaseComponent implements ComponentCanDeactivate, 
 	public onRestore(): void {
 		this.form_mode !== FormMode.RESTORE ? this.initRestoreBackup() : this.onClose();
 	}
+	public onIssue(): void {
+		this.form_mode !== FormMode.ISSUE ? this.initIssueEcash() : this.onClose();
+	}
 	public onRefresh(): void {
 		this.reloadDynamicData();
 	}
@@ -423,6 +434,7 @@ export class MintSubsectionDatabaseComponent implements ComponentCanDeactivate, 
 	public onClose(): void {
 		this.form_backup.reset();
 		this.form_restore.reset();
+		this.form_issue.reset({amount: null, unit: this.form_issue.get('unit')?.value, method: 'bolt11', description: ''});
 		this.form_mode = null;
 		this.eventService.registerEvent(null);
 		this.cdr.detectChanges();
@@ -540,6 +552,62 @@ export class MintSubsectionDatabaseComponent implements ComponentCanDeactivate, 
 			behavior: 'smooth',
 			block: 'start',
 			inline: 'nearest',
+		});
+	}
+
+	private initIssueEcash(): void {
+		this.form_mode = FormMode.ISSUE;
+		const default_unit = (this.unit_options?.[0]?.value as MintUnit | undefined) ?? MintUnit.sat;
+		this.form_issue.patchValue({
+			unit: default_unit,
+			method: 'bolt11',
+		});
+		this.issue_form.nativeElement.scrollIntoView({
+			behavior: 'smooth',
+			block: 'start',
+			inline: 'nearest',
+		});
+	}
+
+	public onIssueSubmit(): void {
+		if (this.form_issue.invalid) {
+			this.eventService.registerEvent(
+				new EventData({
+					type: 'WARNING',
+					message: 'Amount and unit are required',
+				}),
+			);
+			return;
+		}
+
+		const amount = Number(this.form_issue.get('amount')?.value);
+		const unit = this.form_issue.get('unit')?.value as MintUnit;
+		const method = this.form_issue.get('method')?.value || 'bolt11';
+		const description = this.form_issue.get('description')?.value || undefined;
+
+		this.mintService.adminIssueMintNut04Quote(amount, unit, method, description).subscribe({
+			next: (response) => {
+				const issued = response.mint_nut04_admin_issue;
+				this.eventService.registerEvent(
+					new EventData({
+						type: 'SUCCESS',
+						message: `Issued ${issued.amount} ${issued.unit} (quote ${issued.quote_id})`,
+					}),
+				);
+				this.form_mode = null;
+				this.form_issue.reset({amount: null, unit, method: 'bolt11', description: ''});
+				this.page_settings.type = MintDataType.MintMints;
+				this.reloadDynamicData();
+				this.cdr.detectChanges();
+			},
+			error: (errors: OrchardErrors) => {
+				this.eventService.registerEvent(
+					new EventData({
+						type: 'ERROR',
+						message: errors.errors[0].getFullError(),
+					}),
+				);
+			},
 		});
 	}
 

--- a/src/client/modules/mint/services/mint/mint.queries.ts
+++ b/src/client/modules/mint/services/mint/mint.queries.ts
@@ -449,6 +449,17 @@ mutation MintNut04QuoteUpdate($mint_nut04_quote_update: MintNut04QuoteUpdateInpu
 	}
 }`;
 
+export const MINT_NUT04_ADMIN_ISSUE_MUTATION = `
+mutation MintNut04AdminIssue($mint_nut04_admin_issue: MintNut04AdminIssueInput!) {
+	mint_nut04_admin_issue(mint_nut04_admin_issue: $mint_nut04_admin_issue) {
+		quote_id
+		request
+		amount
+		unit
+		state
+	}
+}`;
+
 export const MINT_NUT05_QUOTE_UPDATE_MUTATION = `
 mutation MintNut05QuoteUpdate($mint_nut05_quote_update: MintNut05QuoteUpdateInput!) {
 	mint_nut05_quote_update(mint_nut05_quote_update: $mint_nut05_quote_update) {

--- a/src/client/modules/mint/services/mint/mint.service.ts
+++ b/src/client/modules/mint/services/mint/mint.service.ts
@@ -41,6 +41,7 @@ import {
 	MintContactAddResponse,
 	MintQuoteTtlUpdateResponse,
 	MintNut04UpdateResponse,
+	MintNut04AdminIssueResponse,
 	MintNut05UpdateResponse,
 	MintNut04QuoteUpdateResponse,
 	MintNut05QuoteUpdateResponse,
@@ -102,6 +103,7 @@ import {
 	MINT_CONTACT_ADD_MUTATION,
 	MINT_QUOTE_TTL_MUTATION,
 	MINT_NUT04_UPDATE_MUTATION,
+	MINT_NUT04_ADMIN_ISSUE_MUTATION,
 	MINT_NUT05_UPDATE_MUTATION,
 	MINT_NUT04_QUOTE_UPDATE_MUTATION,
 	MINT_NUT05_QUOTE_UPDATE_MUTATION,
@@ -1124,6 +1126,33 @@ export class MintService {
 			}),
 			catchError((error) => {
 				console.error('Error updating mint:', error);
+				return throwError(() => error);
+			}),
+		);
+	}
+
+	public adminIssueMintNut04Quote(
+		amount: number,
+		unit: MintUnit,
+		method: string = 'bolt11',
+		description?: string,
+	): Observable<MintNut04AdminIssueResponse> {
+		const query = getApiQuery(MINT_NUT04_ADMIN_ISSUE_MUTATION, {
+			mint_nut04_admin_issue: {
+				amount,
+				unit,
+				method,
+				description: description?.trim() ? description.trim() : undefined,
+			},
+		});
+
+		return this.http.post<OrchardRes<MintNut04AdminIssueResponse>>(this.apiService.api, query).pipe(
+			map((response) => {
+				if (response.errors) throw new OrchardErrors(response.errors);
+				return response.data;
+			}),
+			catchError((error) => {
+				console.error('Error issuing mint quote without payment:', error);
 				return throwError(() => error);
 			}),
 		);

--- a/src/client/modules/mint/types/mint.types.ts
+++ b/src/client/modules/mint/types/mint.types.ts
@@ -244,6 +244,16 @@ export type MintNut04QuoteUpdateResponse = {
 	mint_nut04_quote_update: OrchardMintNut04QuoteUpdate;
 };
 
+export type MintNut04AdminIssueResponse = {
+	mint_nut04_admin_issue: {
+		quote_id: string;
+		request?: string;
+		amount: number;
+		unit: MintUnit;
+		state: MintQuoteState;
+	};
+};
+
 export type MintNut05QuoteUpdateResponse = {
 	mint_nut05_quote_update: OrchardMintNut05QuoteUpdate;
 };

--- a/src/server/modules/api/mint/mintquote/mintmintquote.input.ts
+++ b/src/server/modules/api/mint/mintquote/mintmintquote.input.ts
@@ -1,5 +1,7 @@
 /* Core Dependencies */
 import {InputType, Field, Int} from '@nestjs/graphql';
+/* Application Dependencies */
+import {MintUnit} from '@server/modules/cashu/cashu.enums';
 
 @InputType()
 export class MintNut04UpdateInput {
@@ -29,4 +31,19 @@ export class MintNut04QuoteUpdateInput {
 
 	@Field()
 	state: string;
+}
+
+@InputType()
+export class MintNut04AdminIssueInput {
+	@Field(() => Int)
+	amount: number;
+
+	@Field(() => MintUnit)
+	unit: MintUnit;
+
+	@Field({defaultValue: 'bolt11'})
+	method: string;
+
+	@Field({nullable: true})
+	description?: string;
 }

--- a/src/server/modules/api/mint/mintquote/mintmintquote.model.ts
+++ b/src/server/modules/api/mint/mintquote/mintmintquote.model.ts
@@ -92,3 +92,35 @@ export class OrchardMintNut04QuoteUpdate {
 	@Field()
 	state: string;
 }
+
+@ObjectType()
+export class OrchardMintNut04AdminIssue {
+	@Field()
+	quote_id: string;
+
+	@Field({nullable: true})
+	request?: string;
+
+	@Field(() => Int)
+	amount: number;
+
+	@Field(() => MintUnit)
+	unit: MintUnit;
+
+	@Field(() => MintQuoteState)
+	state: MintQuoteState;
+
+	constructor(data: {
+		quote_id: string;
+		request?: string;
+		amount: number;
+		unit: MintUnit;
+		state: MintQuoteState;
+	}) {
+		this.quote_id = data.quote_id;
+		this.request = data.request;
+		this.amount = data.amount;
+		this.unit = data.unit;
+		this.state = data.state;
+	}
+}

--- a/src/server/modules/api/mint/mintquote/mintmintquote.module.ts
+++ b/src/server/modules/api/mint/mintquote/mintmintquote.module.ts
@@ -3,6 +3,7 @@ import {Module} from '@nestjs/common';
 /* Application Dependencies */
 import {CashuMintDatabaseModule} from '@server/modules/cashu/mintdb/cashumintdb.module';
 import {CashuMintRpcModule} from '@server/modules/cashu/mintrpc/cashumintrpc.module';
+import {CashuMintApiModule} from '@server/modules/cashu/mintapi/cashumintapi.module';
 import {MintService} from '@server/modules/api/mint/mint.service';
 import {ErrorModule} from '@server/modules/error/error.module';
 /* Local Dependencies */
@@ -10,7 +11,7 @@ import {MintMintQuoteService} from './mintmintquote.service';
 import {MintMintQuoteResolver} from './mintmintquote.resolver';
 
 @Module({
-	imports: [CashuMintDatabaseModule, CashuMintRpcModule, ErrorModule],
+	imports: [CashuMintDatabaseModule, CashuMintRpcModule, CashuMintApiModule, ErrorModule],
 	providers: [MintMintQuoteResolver, MintMintQuoteService, MintService],
 })
 export class MintMintQuoteModule {}

--- a/src/server/modules/api/mint/mintquote/mintmintquote.resolver.ts
+++ b/src/server/modules/api/mint/mintquote/mintmintquote.resolver.ts
@@ -9,8 +9,8 @@ import {UserRole} from '@server/modules/user/user.enums';
 /* Local Dependencies */
 import {MintMintQuoteService} from './mintmintquote.service';
 import {OrchardMintMintQuote} from './mintmintquote.model';
-import {MintNut04UpdateInput, MintNut04QuoteUpdateInput} from './mintmintquote.input';
-import {OrchardMintNut04Update, OrchardMintNut04QuoteUpdate} from './mintmintquote.model';
+import {MintNut04UpdateInput, MintNut04QuoteUpdateInput, MintNut04AdminIssueInput} from './mintmintquote.input';
+import {OrchardMintNut04Update, OrchardMintNut04QuoteUpdate, OrchardMintNut04AdminIssue} from './mintmintquote.model';
 
 @Resolver()
 export class MintMintQuoteResolver {
@@ -48,5 +48,15 @@ export class MintMintQuoteResolver {
 		const tag = 'MUTATION { mint_nut04_quote_update }';
 		this.logger.debug(tag);
 		return await this.mintMintQuoteService.updateMintNut04Quote(tag, mint_nut04_quote_update);
+	}
+
+	@Roles(UserRole.ADMIN, UserRole.MANAGER)
+	@Mutation(() => OrchardMintNut04AdminIssue)
+	async mint_nut04_admin_issue(
+		@Args('mint_nut04_admin_issue') mint_nut04_admin_issue: MintNut04AdminIssueInput,
+	): Promise<OrchardMintNut04AdminIssue> {
+		const tag = 'MUTATION { mint_nut04_admin_issue }';
+		this.logger.debug(tag);
+		return await this.mintMintQuoteService.adminIssueMintNut04Quote(tag, mint_nut04_admin_issue);
 	}
 }

--- a/src/server/modules/api/mint/mintquote/mintmintquote.service.spec.ts
+++ b/src/server/modules/api/mint/mintquote/mintmintquote.service.spec.ts
@@ -4,10 +4,12 @@ import {expect} from '@jest/globals';
 /* Application Dependencies */
 import {CashuMintDatabaseService} from '@server/modules/cashu/mintdb/cashumintdb.service';
 import {CashuMintRpcService} from '@server/modules/cashu/mintrpc/cashumintrpc.service';
+import {CashuMintApiService} from '@server/modules/cashu/mintapi/cashumintapi.service';
 import {MintService} from '@server/modules/api/mint/mint.service';
 import {ErrorService} from '@server/modules/error/error.service';
 import {OrchardErrorCode} from '@server/modules/error/error.types';
 import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
+import {MintQuoteState, MintUnit} from '@server/modules/cashu/cashu.enums';
 /* Local Dependencies */
 import {MintMintQuoteService} from './mintmintquote.service';
 import {OrchardMintMintQuote} from './mintmintquote.model';
@@ -16,6 +18,7 @@ describe('MintMintQuoteService', () => {
 	let mintMintQuoteService: MintMintQuoteService;
 	let mintDbService: jest.Mocked<CashuMintDatabaseService>;
 	let mintRpcService: jest.Mocked<CashuMintRpcService>;
+	let mintApiService: jest.Mocked<CashuMintApiService>;
 	let errorService: jest.Mocked<ErrorService>;
 
 	beforeEach(async () => {
@@ -24,6 +27,7 @@ describe('MintMintQuoteService', () => {
 				MintMintQuoteService,
 				{provide: CashuMintDatabaseService, useValue: {getMintMintQuotes: jest.fn()}},
 				{provide: CashuMintRpcService, useValue: {updateNut04: jest.fn(), updateNut04Quote: jest.fn()}},
+				{provide: CashuMintApiService, useValue: {createMintNut04Quote: jest.fn()}},
 				{provide: MintService, useValue: {withDbClient: jest.fn((fn: any) => fn({}))}},
 				{provide: ErrorService, useValue: {resolveError: jest.fn()}},
 			],
@@ -32,6 +36,7 @@ describe('MintMintQuoteService', () => {
 		mintMintQuoteService = module.get<MintMintQuoteService>(MintMintQuoteService);
 		mintDbService = module.get(CashuMintDatabaseService);
 		mintRpcService = module.get(CashuMintRpcService);
+		mintApiService = module.get(CashuMintApiService);
 		errorService = module.get(ErrorService);
 	});
 
@@ -56,6 +61,44 @@ describe('MintMintQuoteService', () => {
 		mintRpcService.updateNut04Quote.mockResolvedValue({quote_id: '1', state: 'PAID'} as any);
 		const result = await mintMintQuoteService.updateMintNut04Quote('TAG', {quote_id: '1', state: 'PAID'} as any);
 		expect(result).toEqual({quote_id: '1', state: 'PAID'});
+	});
+
+	it('adminIssueMintNut04Quote creates quote then forces PAID state', async () => {
+		mintApiService.createMintNut04Quote.mockResolvedValue({
+			quote: 'q1',
+			request: 'lnbc1...',
+			amount: 21,
+			unit: 'sat' as any,
+		});
+
+		const result = await mintMintQuoteService.adminIssueMintNut04Quote('TAG', {
+			amount: 21,
+			unit: 'sat' as any,
+			method: 'bolt11',
+		});
+
+		expect(mintApiService.createMintNut04Quote).toHaveBeenCalledWith('bolt11', {
+			amount: 21,
+			unit: MintUnit.sat,
+			description: undefined,
+		});
+		expect(mintRpcService.updateNut04Quote).toHaveBeenCalledWith({quote_id: 'q1', state: MintQuoteState.PAID});
+		expect(result).toEqual({
+			quote_id: 'q1',
+			request: 'lnbc1...',
+			amount: 21,
+			unit: MintUnit.sat,
+			state: MintQuoteState.PAID,
+		});
+	});
+
+	it('adminIssueMintNut04Quote wraps API errors into OrchardApiError', async () => {
+		mintApiService.createMintNut04Quote.mockRejectedValue(new Error('boom'));
+		errorService.resolveError.mockReturnValue({code: OrchardErrorCode.MintRpcActionError});
+
+		await expect(
+			mintMintQuoteService.adminIssueMintNut04Quote('TAG', {amount: 10, unit: 'sat' as any, method: 'bolt11'}),
+		).rejects.toBeInstanceOf(OrchardApiError);
 	});
 
 	it('wraps errors via resolveError and throws OrchardApiError', async () => {

--- a/src/server/modules/api/mint/mintquote/mintmintquote.service.ts
+++ b/src/server/modules/api/mint/mintquote/mintmintquote.service.ts
@@ -3,16 +3,18 @@ import {Injectable, Logger} from '@nestjs/common';
 /* Application Dependencies */
 import {CashuMintDatabaseService} from '@server/modules/cashu/mintdb/cashumintdb.service';
 import {CashuMintRpcService} from '@server/modules/cashu/mintrpc/cashumintrpc.service';
+import {CashuMintApiService} from '@server/modules/cashu/mintapi/cashumintapi.service';
 import {CashuMintMintQuote} from '@server/modules/cashu/mintdb/cashumintdb.types';
 import {CashuMintMintQuotesArgs} from '@server/modules/cashu/mintdb/cashumintdb.interfaces';
+import {MintQuoteState} from '@server/modules/cashu/cashu.enums';
 import {OrchardErrorCode} from '@server/modules/error/error.types';
 import {OrchardApiError} from '@server/modules/graphql/classes/orchard-error.class';
 import {MintService} from '@server/modules/api/mint/mint.service';
 import {ErrorService} from '@server/modules/error/error.service';
 /* Local Dependencies */
 import {OrchardMintMintQuote} from './mintmintquote.model';
-import {MintNut04UpdateInput, MintNut04QuoteUpdateInput} from './mintmintquote.input';
-import {OrchardMintNut04Update, OrchardMintNut04QuoteUpdate} from './mintmintquote.model';
+import {MintNut04UpdateInput, MintNut04QuoteUpdateInput, MintNut04AdminIssueInput} from './mintmintquote.input';
+import {OrchardMintNut04Update, OrchardMintNut04QuoteUpdate, OrchardMintNut04AdminIssue} from './mintmintquote.model';
 
 @Injectable()
 export class MintMintQuoteService {
@@ -21,6 +23,7 @@ export class MintMintQuoteService {
 	constructor(
 		private cashuMintDatabaseService: CashuMintDatabaseService,
 		private cashuMintRpcService: CashuMintRpcService,
+		private cashuMintApiService: CashuMintApiService,
 		private mintService: MintService,
 		private errorService: ErrorService,
 	) {}
@@ -55,6 +58,36 @@ export class MintMintQuoteService {
 		try {
 			await this.cashuMintRpcService.updateNut04Quote(mint_nut04_quote_update);
 			return mint_nut04_quote_update;
+		} catch (error) {
+			const orchard_error = this.errorService.resolveError(this.logger, error, tag, {
+				errord: OrchardErrorCode.MintRpcActionError,
+			});
+			throw new OrchardApiError(orchard_error);
+		}
+	}
+
+	async adminIssueMintNut04Quote(
+		tag: string,
+		mint_nut04_admin_issue: MintNut04AdminIssueInput,
+	): Promise<OrchardMintNut04AdminIssue> {
+		try {
+			const created_quote = await this.cashuMintApiService.createMintNut04Quote(mint_nut04_admin_issue.method, {
+				amount: mint_nut04_admin_issue.amount,
+				unit: mint_nut04_admin_issue.unit,
+				description: mint_nut04_admin_issue.description,
+			});
+
+			if (!created_quote.quote) throw new Error('Mint API response missing quote id');
+
+			await this.cashuMintRpcService.updateNut04Quote({quote_id: created_quote.quote, state: MintQuoteState.PAID});
+
+			return new OrchardMintNut04AdminIssue({
+				quote_id: created_quote.quote,
+				request: created_quote.request,
+				amount: created_quote.amount ?? mint_nut04_admin_issue.amount,
+				unit: created_quote.unit ?? mint_nut04_admin_issue.unit,
+				state: MintQuoteState.PAID,
+			});
 		} catch (error) {
 			const orchard_error = this.errorService.resolveError(this.logger, error, tag, {
 				errord: OrchardErrorCode.MintRpcActionError,

--- a/src/server/modules/cashu/mintapi/cashumintapi.service.spec.ts
+++ b/src/server/modules/cashu/mintapi/cashumintapi.service.spec.ts
@@ -85,4 +85,28 @@ describe('CashuMintApiService', () => {
 			headers: {'Content-Type': 'application/json'},
 		});
 	});
+
+	it('creates a mint quote for nut04', async () => {
+		configService.get.mockReturnValue('https://mint');
+		const json = jest.fn().mockResolvedValue({quote: 'q1', request: 'lnbc1...'});
+		fetchService.fetchWithProxy.mockResolvedValue({ok: true, status: 200, json} as any);
+
+		const out = await cashuMintApiService.createMintNut04Quote('bolt11', {amount: 21, unit: 'sat' as any});
+		expect(fetchService.fetchWithProxy).toHaveBeenCalledWith('https://mint/v1/mint/quote/bolt11', {
+			method: 'POST',
+			headers: {'Content-Type': 'application/json'},
+			body: JSON.stringify({amount: 21, unit: 'sat'}),
+		});
+		expect(out).toEqual({quote: 'q1', request: 'lnbc1...'});
+	});
+
+	it('throws when quote creation returns non-200 status', async () => {
+		configService.get.mockReturnValue('https://mint');
+		const text = jest.fn().mockResolvedValue('bad request');
+		fetchService.fetchWithProxy.mockResolvedValue({ok: false, status: 400, text} as any);
+
+		await expect(cashuMintApiService.createMintNut04Quote('bolt11', {amount: 21, unit: 'sat' as any})).rejects.toThrow(
+			'Mint API quote creation failed (400): bad request',
+		);
+	});
 });

--- a/src/server/modules/cashu/mintapi/cashumintapi.service.ts
+++ b/src/server/modules/cashu/mintapi/cashumintapi.service.ts
@@ -4,7 +4,7 @@ import {ConfigService} from '@nestjs/config';
 /* Application Dependencies */
 import {FetchService} from '@server/modules/fetch/fetch.service';
 /* Local Dependencies  */
-import {CashuMintInfo} from './cashumintapi.types';
+import {CashuMintInfo, CashuMintNut04QuoteCreateRequest, CashuMintNut04QuoteCreateResponse} from './cashumintapi.types';
 
 @Injectable()
 export class CashuMintApiService {
@@ -18,6 +18,22 @@ export class CashuMintApiService {
 			method: 'GET',
 			headers: {'Content-Type': 'application/json'},
 		});
+		return response.json();
+	}
+
+	async createMintNut04Quote(
+		method: string,
+		payload: CashuMintNut04QuoteCreateRequest,
+	): Promise<CashuMintNut04QuoteCreateResponse> {
+		const response = await this.fetchService.fetchWithProxy(`${this.configService.get('cashu.api')}/v1/mint/quote/${method}`, {
+			method: 'POST',
+			headers: {'Content-Type': 'application/json'},
+			body: JSON.stringify(payload),
+		});
+		if (!response.ok) {
+			const error_body = await response.text();
+			throw new Error(`Mint API quote creation failed (${response.status}): ${error_body}`);
+		}
 		return response.json();
 	}
 }

--- a/src/server/modules/cashu/mintapi/cashumintapi.types.ts
+++ b/src/server/modules/cashu/mintapi/cashumintapi.types.ts
@@ -1,4 +1,4 @@
-import {MintUnit} from '@server/modules/cashu/cashu.enums';
+import {MintUnit, MintQuoteState} from '@server/modules/cashu/cashu.enums';
 
 export type CashuMintInfo = {
 	name: string;
@@ -93,4 +93,20 @@ export type CashuNutSupported = {
 export type CashuCachedEndpoint = {
 	method: string;
 	path: string;
+};
+
+export type CashuMintNut04QuoteCreateRequest = {
+	amount: number;
+	unit: MintUnit;
+	description?: string;
+};
+
+export type CashuMintNut04QuoteCreateResponse = {
+	quote: string;
+	request: string;
+	amount?: number;
+	unit?: MintUnit;
+	state?: MintQuoteState;
+	paid?: boolean;
+	expiry?: number;
 };


### PR DESCRIPTION
## Summary
- add a new admin GraphQL mutation `mint_nut04_admin_issue` that creates a NUT-04 mint quote via mint API and immediately forces the quote to `PAID` via mint RPC
- add an **Issue Ecash (Admin)** action in Mint Database UI with a form for amount/unit/method/description
- wire client query/service/types for the new mutation and refresh mint quote data after issuance
- add server unit tests for new mint API quote creation and admin issuance service flow

## Why
`cashubtc/nutshell#556` calls out admin-level issuance without requiring payment as a remaining requirement for admin UI flows.

## Validation
- `npx jest src/server/modules/cashu/mintapi/cashumintapi.service.spec.ts src/server/modules/api/mint/mintquote/mintmintquote.service.spec.ts`
- `npx tsc -p tsconfig.server.json --noEmit`
- `npx eslint` on all touched TS files

## Notes
- Full `npm run build` is currently blocked in this environment because schema/codegen bootstrap is not available (`schema.gql` generation step exits non-zero).
